### PR TITLE
Adjust ScreenEvaluation metrics to better match AC

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -188,11 +188,11 @@ NextScreen="ScreenDemonstration2"
 PrevScreen=Branch.NoiseTrigger()
 StartScreen=Branch.TitleMenu()
 PlayMusic=false
-SecondsToShow=60
+SecondsToShow=30
 
 LightsMode="LightsMode_Demonstration"
-DifficultiesToShow="easy,medium,hard,challenge"
-ShowCourseModifiersProbability=0
+DifficultiesToShow="beginner,easy,medium"
+ShowCourseModifiersProbability=0.5
 AllowAdvancedModifiers=false
 AllowStyleTypes="TwoPlayersTwoSides"
 AllowStepTypes="dance-single"


### PR DESCRIPTION
Noticed while leaving the theme idling that it would fail to find any steps sometimes and songs would last for too long. These value changes should match with ITG2AC and OITG metrics.