### PR TITLE
Dutch != Deutsch

### DIFF
--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -1390,7 +1390,7 @@ nd=nd
 rd=rd
 
 [NativeLanguages]
-de=Dutch
+de=Deutsch
 en=English
 es=Español
 fr=Français


### PR DESCRIPTION
Dutch is English for Nederlands, not German for German, this is very annoying because it will selected by players assuming Dutch will start the game in Dutch but it will actually start the game in German